### PR TITLE
Gd thickness changed to increase control rod worth

### DIFF
--- a/v1-4/core.ini
+++ b/v1-4/core.ini
@@ -39,8 +39,8 @@ surf 121 cyl 0.0 0.0 1.425      %IR for  CR GT
 
 surf 122 cyl 0.0 0.0 0.855      %OR for CR clad
 surf 123 cyl 0.0 0.0 0.810      %OR for CR pois
-surf 124 cyl 0.0 0.0 0.630      %OR for CR clad
-surf 125 cyl 0.0 0.0 0.5925     %OR for CR air
+surf 124 cyl 0.0 0.0 0.430      %OR for CR clad
+surf 125 cyl 0.0 0.0 0.3925     %OR for CR air
 surf 126 pz -150                % Assumed rod is 300 cm long
 surf 129 pz 150                 % Ignoring end caps
 


### PR DESCRIPTION
Closes issue #8. Control rod worth for all rod increased from about **800pcm** to **1121+-26pcm.**

Hopefully, it is enough for transient simulations.